### PR TITLE
Configure Jest and add substituteWithJSONata tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testPathIgnorePatterns: ['/node_modules/', '/lib/'],
+};

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lib/**/*"
   ],
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "build": "tsc",
     "postinstall": "yarn build",
     "gen-cars": "tsx scripts/generate-car-constants.ts"
@@ -49,6 +49,9 @@
   "homepage": "https://github.com/pluspingya/getacar-common#readme",
   "devDependencies": {
     "@types/jsonata": "^1.5.1",
+    "@types/jest": "^29.5.5",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
     "csv-parse": "^6.1.0",
     "fs": "^0.0.1-security",
     "path": "^0.12.7",

--- a/src/utils/strings.test.ts
+++ b/src/utils/strings.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from '@jest/globals';
+import { substituteWithJSONata } from './strings';
+
+describe('substituteWithJSONata', () => {
+  it('replaces JSONata expressions with values', async () => {
+    const template = 'Hello {user.name}!';
+    const data = { user: { name: 'Alice' } };
+    await expect(substituteWithJSONata(template, data)).resolves.toBe('Hello Alice!');
+  });
+
+  it('formats Date values using provided timezone and format', async () => {
+    const template = 'Date: {date}';
+    const data = {
+      date: new Date('2023-01-01T00:00:00Z'),
+      timezone: 'UTC',
+      dateTimeFormat: 'yyyy-MM-dd',
+    };
+    await expect(substituteWithJSONata(template, data)).resolves.toBe('Date: 2023-01-01');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest, ts-jest, and type definitions
- configure Jest for TS project
- add tests for substituteWithJSONata

## Testing
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68a59b9d4bf0832faf9a18bb6e28e6d9